### PR TITLE
Fix for first keypress firing the scrolling event

### DIFF
--- a/redditnav.js
+++ b/redditnav.js
@@ -113,7 +113,7 @@ chrome.storage.sync.get({
 });
 
 document.addEventListener('keydown', (event) => {
-  if (event.target.value)
+  if (event.target.value != null)
     return;
 
   if (event.keyCode === 81) // Q


### PR DESCRIPTION
`event.target.value` returns `false` on an empty textarea, causing the scroll event to fire if the first letter typed is Q or W. Seems to be new behaviour, as I don't really remember it ever happening before.

@justinthec check if `event.target.value != null` works for you fam, I haven't run into a case yet where it's broken anything and it's fixed Q/W as the first letter in a comment scrolling the page for me.