### PR TITLE
Chrome v61 scrolling bugfix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
     "name": "Reddit Nav",
     "description": "Effortlessly scroll through comment threads on Reddit.",
-    "version": "1.1.1",
+    "version": "1.1.2",
 
     "browser_action": {
         "default_icon": "popup/icon128.png",

--- a/redditnav.js
+++ b/redditnav.js
@@ -36,7 +36,9 @@ function animateScrollTo(position, duration) {
 }
 
 function getNodePos(node, direction) {
-  const topOfNode = node.getBoundingClientRect().top + document.body.scrollTop;
+  const topOfNode = node.getBoundingClientRect().top +
+    (document.documentElement.scrollTop || document.body.scrollTop || window.scrollY);
+
   if (direction === directions.DOWN)
     return Math.floor(topOfNode);
   else


### PR DESCRIPTION
New version of Chrome replaces `document.body.scrollTop` with `document.documentElement.scrollTop`, threw in a couple `||`s in case one or both of the `scrollTops` are broken in older (or upcoming) versions of Chrome.